### PR TITLE
Added E_DEPRECATED to error_reporting resets.

### DIFF
--- a/index.php
+++ b/index.php
@@ -8,7 +8,7 @@
  */
  
 ini_set('display_errors', TRUE);
-error_reporting(E_ALL & ~E_STRICT);
+error_reporting(E_ALL & ~E_STRICT & ~E_DEPRECATED);
 
 /**
  * Set the server variable for document root. A lot of 

--- a/libraries/Scaffold/Scaffold.php
+++ b/libraries/Scaffold/Scaffold.php
@@ -301,7 +301,7 @@ class Scaffold extends Scaffold_Utils
 		if(SCAFFOLD_PRODUCTION === false)
 		{	
 			ini_set('display_errors', true);
-			error_reporting(E_ALL & ~E_STRICT);
+			error_reporting(E_ALL & ~E_STRICT & ~E_DEPRECATED);
 		}
 		else
 		{


### PR DESCRIPTION
Depreciation warnings are littering generated css on recent php versions.
